### PR TITLE
remove override requirement on most methods

### DIFF
--- a/HTTP Client Abstract.vipb
+++ b/HTTP Client Abstract.vipb
@@ -1,7 +1,7 @@
-<VI_Package_Builder_Settings Version="2020.1" Created_Date="2025-08-19 10:27:18" Modified_Date="2025-08-22 22:09:25" Creator="Jim" Comments="" ID="51803296e9dd0b7761cc1dc3294dfdab">
+<VI_Package_Builder_Settings Version="2020.1" Created_Date="2025-08-19 10:27:18" Modified_Date="2025-08-23 12:12:56" Creator="Jim" Comments="" ID="70c5490170cb3088f7282f865e4a808c">
   <Library_General_Settings>
     <Package_File_Name>vipm_io_http_client_abstract</Package_File_Name>
-    <Library_Version>0.3.0.16</Library_Version>
+    <Library_Version>0.3.1.17</Library_Version>
     <Auto_Increment_Version>false</Auto_Increment_Version>
     <Library_Source_Folder>lv_src</Library_Source_Folder>
     <Library_Output_Folder>built</Library_Output_Folder>
@@ -38,7 +38,7 @@ Includes a default implementation of the built-in LabVIEW HTTP Client and uses t
       <Copyright/>
       <Packager>visit homepage - various contributors</Packager>
       <URL>https://github.com/vipm-io/http-client-plugin-base</URL>
-      <Release_Notes>- converted abstract base class into an interface
+      <Release_Notes>- now only `Open Session.vi` and `Close Session.vi` require overrides, so that implementations can choose which ones to override. Default implementations will return errors so that callers know that a plug-in is missing that method.
 
 Contributors: @negentropicdev @justiceb @jimkring</Release_Notes>
     </Description>
@@ -460,7 +460,7 @@ Contributors: @negentropicdev @justiceb @jimkring</Release_Notes>
         <Path>lv_src\Classes\Abstract HTTP Client\List Headers.vi</Path>
         <VI_Title/>
       </Items_Data>
-      <GUID>F698EF674A99B5198060AD88F6617949</GUID>
+      <GUID>26BE9C65A8555CC53C803D149A66A6D5</GUID>
     </Functions_Palette_Data>
   </Library_Palette_Definition>
 </VI_Package_Builder_Settings>

--- a/lv_src/Classes/Abstract HTTP Client/Abstract HTTP Client.lvclass
+++ b/lv_src/Classes/Abstract HTTP Client/Abstract HTTP Client.lvclass
@@ -15,157 +15,172 @@
 	<Item Name="API" Type="Folder">
 		<Property Name="NI.SortType" Type="Int">3</Property>
 		<Item Name="Close Handle.vi" Type="VI" URL="../Close Handle.vi">
-			<Property Name="NI.ClassItem.ConnectorPane" Type="Bin">)!#!!!!!!!)!"1!&amp;!!!-!%!!!@````]!!!!"!!%!!!'(!!!!#1!-1#%'=X2B&gt;(6T!!!,1!-!"'.P:'5!!""!-0````]'=W^V=G.F!!!71&amp;!!!Q!!!!%!!AFF=H*P=C"P&gt;81!"!!!!':!=!!?!!"$'EB56&amp;!A1WRJ:7ZU)%&amp;C=X2S97.U,GRW&lt;'FC*E&amp;C=X2S97.U)%B56&amp;!A1WRJ:7ZU)%FO&gt;'6S:G&amp;D:3ZM&gt;G.M98.T!"B)6&amp;21)%.M;76O&gt;#""9H.U=G&amp;D&gt;#"P&gt;81!!#"!5!!$!!!!!1!#%W6S=G^S)'FO)#BO&lt;S"F=H*P=CE!:%"Q!"Y!!%-;3&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1O&lt;(:M;7)G17*T&gt;(*B9X1A3&amp;255#"$&lt;'FF&lt;H1A37ZU:8*G97.F,GRW9WRB=X-!&amp;UB56&amp;!A1WRJ:7ZU)%&amp;C=X2S97.U)'FO!&amp;1!]!!-!!-!"!!%!!5!"!!%!!1!"!!'!!1!"!!(!A!!?!!!$1A!!!!!!!!!!!!!D1M!!!!!!!!!!!!!!!!!!!!!!!!)!!!!!!!!!!!!!!#1!!!!!!%!#!!!!!!</Property>
+			<Property Name="NI.ClassItem.ConnectorPane" Type="Bin">)!#!!!!!!!)!"1!&amp;!!!-!%!!!@````]!!!!"!!%!!!&amp;T!!!!#1!-1#%'=X2B&gt;(6T!!!,1!-!"'.P:'5!!""!-0````]'=W^V=G.F!!!71&amp;!!!Q!!!!%!!AFF=H*P=C"P&gt;81!"!!!!&amp;R!=!!?!!!Z'EB56&amp;!A1WRJ:7ZU)%&amp;C=X2S97.U,GRW&lt;'FC(%&amp;C=X2S97.U)%B56&amp;!A1WRJ:7ZU,GRW9WRB=X-!'%B56&amp;!A1WRJ:7ZU)%&amp;C=X2S97.U)'^V&gt;!!!)%"1!!-!!!!"!!)4:8*S&lt;X)A;7YA+'ZP)'6S=G^S+1";1(!!(A!!/2J)6&amp;21)%.M;76O&gt;#""9H.U=G&amp;D&gt;#ZM&gt;GRJ9BR"9H.U=G&amp;D&gt;#")6&amp;21)%.M;76O&gt;#ZM&gt;G.M98.T!"&gt;)6&amp;21)%.M;76O&gt;#""9H.U=G&amp;D&gt;#"J&lt;A"5!0!!$!!$!!1!"!!&amp;!!1!"!!%!!1!"A!%!!1!"Q)!!(A!!!U)!!!!!!!!!!!!!)U,!!!!!!!!!!!!!!!!!!!!!!!!#!!!!!!!!!!!!!!!E!!!!!!"!!A!!!!!</Property>
 			<Property Name="NI.ClassItem.ExecutionSystem" Type="Int">-1</Property>
 			<Property Name="NI.ClassItem.Flags" Type="Int">16777344</Property>
 			<Property Name="NI.ClassItem.IsStaticMethod" Type="Bool">false</Property>
 			<Property Name="NI.ClassItem.MethodScope" Type="UInt">1</Property>
 			<Property Name="NI.ClassItem.Priority" Type="Int">1</Property>
-			<Property Name="NI.ClassItem.State" Type="Int">1342972416</Property>
+			<Property Name="NI.ClassItem.State" Type="Int">1082139136</Property>
 		</Item>
 		<Item Name="PATCH File.vi" Type="VI" URL="../PATCH File.vi">
-			<Property Name="NI.ClassItem.ConnectorPane" Type="Bin">)!#!!!!!!!)!"1!&amp;!!!-!%!!!@````]!!!!"!!%!!!(R!!!!%!!-1#%'=X2B&gt;(6T!!!,1!-!"'.P:'5!!""!-0````]'=W^V=G.F!!!71&amp;!!!Q!!!!%!!AFF=H*P=C"P&gt;81!$E!Q`````Q2C&lt;W2Z!!!11$$`````"WBF972F=H-!:E"Q!"Y!!%-;3&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1O&lt;(:M;7)G17*T&gt;(*B9X1A3&amp;255#"$&lt;'FF&lt;H1A37ZU:8*G97.F,GRW9WRB=X-!'%B56&amp;!A1WRJ:7ZU)%&amp;C=X2S97.U)'^V&gt;!!!%5!(!!NT&gt;'&amp;U&gt;8-A9W^E:1!%!!!!$5!$!!&gt;U;7VF&lt;X6U!"2!-P````],&lt;X6U=(6U)':J&lt;'5!)%"1!!-!!!!"!!)4:8*S&lt;X)A;7YA+'ZP)'6S=G^S+1!/1$,`````"':J&lt;'5!!!R!-0````]$&gt;8*M!'2!=!!?!!"$'EB56&amp;!A1WRJ:7ZU)%&amp;C=X2S97.U,GRW&lt;'FC*E&amp;C=X2S97.U)%B56&amp;!A1WRJ:7ZU)%FO&gt;'6S:G&amp;D:3ZM&gt;G.M98.T!"&gt;)6&amp;21)%.M;76O&gt;#""9H.U=G&amp;D&gt;#"J&lt;A"5!0!!$!!$!!1!"1!'!!=!#!!*!!I!#Q!-!!U!$A)!!(A!!!U)!!!*!!!!#1!!!)U,!!!*!!!!!!!!!!A!!!!)!!!!#!!!!"!!!!)1!!!!E!!!!!!"!!]!!!!!</Property>
+			<Property Name="NI.ClassItem.ConnectorPane" Type="Bin">)!#!!!!!!!)!"1!&amp;!!!-!%!!!@````]!!!!"!!%!!!(&gt;!!!!%!!-1#%'=X2B&gt;(6T!!!,1!-!"'.P:'5!!""!-0````]'=W^V=G.F!!!71&amp;!!!Q!!!!%!!AFF=H*P=C"P&gt;81!$E!Q`````Q2C&lt;W2Z!!!11$$`````"WBF972F=H-!8%"Q!"Y!!$E;3&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1O&lt;(:M;7)=17*T&gt;(*B9X1A3&amp;255#"$&lt;'FF&lt;H1O&lt;(:D&lt;'&amp;T=Q!93&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1A&lt;X6U!!!21!=!#X.U982V=S"D&lt;W2F!!1!!!!.1!-!"X2J&lt;76P&gt;81!&amp;%!S`````QNP&gt;82Q&gt;81A:GFM:1!A1&amp;!!!Q!!!!%!!B.F=H*P=C"J&lt;C!I&lt;G]A:8*S&lt;X)J!!Z!-P````]%:GFM:1!!$%!Q`````Q.V=GQ!7E"Q!"Y!!$E;3&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1O&lt;(:M;7)=17*T&gt;(*B9X1A3&amp;255#"$&lt;'FF&lt;H1O&lt;(:D&lt;'&amp;T=Q!83&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1A;7Y!6!$Q!!Q!!Q!%!!5!"A!(!!A!#1!+!!M!$!!.!!Y#!!"Y!!!.#!!!#1!!!!E!!!#.#Q!!#1!!!!!!!!!)!!!!#!!!!!A!!!!1!!!#%!!!!*!!!!!!!1!0!!!!!!</Property>
 			<Property Name="NI.ClassItem.ExecutionSystem" Type="Int">-1</Property>
 			<Property Name="NI.ClassItem.Flags" Type="Int">16777344</Property>
 			<Property Name="NI.ClassItem.IsStaticMethod" Type="Bool">false</Property>
 			<Property Name="NI.ClassItem.MethodScope" Type="UInt">1</Property>
+			<Property Name="NI.ClassItem.MustOverride" Type="Bool">false</Property>
 			<Property Name="NI.ClassItem.Priority" Type="Int">1</Property>
-			<Property Name="NI.ClassItem.State" Type="Int">1342972416</Property>
+			<Property Name="NI.ClassItem.State" Type="Int">1082139136</Property>
 		</Item>
 		<Item Name="PATCH Buffer.vi" Type="VI" URL="../PATCH Buffer.vi">
-			<Property Name="NI.ClassItem.ConnectorPane" Type="Bin">)!#!!!!!!!)!"1!&amp;!!!-!%!!!@````]!!!!"!!%!!!(T!!!!%!!-1#%'=X2B&gt;(6T!!!,1!-!"'.P:'5!!""!-0````]'=W^V=G.F!!!71&amp;!!!Q!!!!%!!AFF=H*P=C"P&gt;81!$E!Q`````Q2C&lt;W2Z!!!11$$`````"WBF972F=H-!:E"Q!"Y!!%-;3&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1O&lt;(:M;7)G17*T&gt;(*B9X1A3&amp;255#"$&lt;'FF&lt;H1A37ZU:8*G97.F,GRW9WRB=X-!'%B56&amp;!A1WRJ:7ZU)%&amp;C=X2S97.U)'^V&gt;!!!%5!(!!NT&gt;'&amp;U&gt;8-A9W^E:1!%!!!!$5!$!!&gt;U;7VF&lt;X6U!"2!-P````],&lt;X6U=(6U)':J&lt;'5!)%"1!!-!!!!"!!)4:8*S&lt;X)A;7YA+'ZP)'6S=G^S+1!11$$`````"G*V:G:F=A!!$%!Q`````Q.V=GQ!:%"Q!"Y!!%-;3&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1O&lt;(:M;7)G17*T&gt;(*B9X1A3&amp;255#"$&lt;'FF&lt;H1A37ZU:8*G97.F,GRW9WRB=X-!&amp;UB56&amp;!A1WRJ:7ZU)%&amp;C=X2S97.U)'FO!&amp;1!]!!-!!-!"!!&amp;!!9!"Q!)!!E!#A!,!!Q!$1!/!A!!?!!!$1A!!!E!!!!*!!!!D1M!!!E!!!!!!!!!#!!!!!A!!!!)!!!##!!!!B!!!!#1!!!!!!%!$Q!!!!!</Property>
+			<Property Name="NI.ClassItem.ConnectorPane" Type="Bin">)!#!!!!!!!)!"1!&amp;!!!-!%!!!@````]!!!!"!!%!!!(@!!!!%!!-1#%'=X2B&gt;(6T!!!,1!-!"'.P:'5!!""!-0````]'=W^V=G.F!!!71&amp;!!!Q!!!!%!!AFF=H*P=C"P&gt;81!$E!Q`````Q2C&lt;W2Z!!!11$$`````"WBF972F=H-!8%"Q!"Y!!$E;3&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1O&lt;(:M;7)=17*T&gt;(*B9X1A3&amp;255#"$&lt;'FF&lt;H1O&lt;(:D&lt;'&amp;T=Q!93&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1A&lt;X6U!!!21!=!#X.U982V=S"D&lt;W2F!!1!!!!.1!-!"X2J&lt;76P&gt;81!&amp;%!S`````QNP&gt;82Q&gt;81A:GFM:1!A1&amp;!!!Q!!!!%!!B.F=H*P=C"J&lt;C!I&lt;G]A:8*S&lt;X)J!""!-0````]'9H6G:G6S!!!-1$$`````!X6S&lt;!";1(!!(A!!/2J)6&amp;21)%.M;76O&gt;#""9H.U=G&amp;D&gt;#ZM&gt;GRJ9BR"9H.U=G&amp;D&gt;#")6&amp;21)%.M;76O&gt;#ZM&gt;G.M98.T!"&gt;)6&amp;21)%.M;76O&gt;#""9H.U=G&amp;D&gt;#"J&lt;A"5!0!!$!!$!!1!"1!'!!=!#!!*!!I!#Q!-!!U!$A)!!(A!!!U)!!!*!!!!#1!!!)U,!!!*!!!!!!!!!!A!!!!)!!!!#!!!!AA!!!)1!!!!E!!!!!!"!!]!!!!!</Property>
 			<Property Name="NI.ClassItem.ExecutionSystem" Type="Int">-1</Property>
 			<Property Name="NI.ClassItem.Flags" Type="Int">16777344</Property>
 			<Property Name="NI.ClassItem.IsStaticMethod" Type="Bool">false</Property>
 			<Property Name="NI.ClassItem.MethodScope" Type="UInt">1</Property>
+			<Property Name="NI.ClassItem.MustOverride" Type="Bool">false</Property>
 			<Property Name="NI.ClassItem.Priority" Type="Int">1</Property>
-			<Property Name="NI.ClassItem.State" Type="Int">1342972416</Property>
+			<Property Name="NI.ClassItem.State" Type="Int">1082139136</Property>
 		</Item>
 		<Item Name="DELETE.vi" Type="VI" URL="../DELETE.vi">
-			<Property Name="NI.ClassItem.ConnectorPane" Type="Bin">)!#!!!!!!!)!"1!&amp;!!!-!%!!!@````]!!!!"!!%!!!(L!!!!$Q!-1#%'=X2B&gt;(6T!!!,1!-!"'.P:'5!!""!-0````]'=W^V=G.F!!!71&amp;!!!Q!!!!%!!AFF=H*P=C"P&gt;81!$E!Q`````Q2C&lt;W2Z!!!11$$`````"WBF972F=H-!:E"Q!"Y!!%-;3&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1O&lt;(:M;7)G17*T&gt;(*B9X1A3&amp;255#"$&lt;'FF&lt;H1A37ZU:8*G97.F,GRW9WRB=X-!'%B56&amp;!A1WRJ:7ZU)%&amp;C=X2S97.U)'^V&gt;!!!%5!(!!NT&gt;'&amp;U&gt;8-A9W^E:1!%!!!!&amp;5!$!!^U;7VF&lt;X6U)#AR-$!Q-#E!&amp;%!S`````QNP&gt;82Q&gt;81A:GFM:1!A1&amp;!!!Q!!!!%!!B.F=H*P=C"J&lt;C!I&lt;G]A:8*S&lt;X)J!!R!-0````]$&gt;8*M!'2!=!!?!!"$'EB56&amp;!A1WRJ:7ZU)%&amp;C=X2S97.U,GRW&lt;'FC*E&amp;C=X2S97.U)%B56&amp;!A1WRJ:7ZU)%FO&gt;'6S:G&amp;D:3ZM&gt;G.M98.T!"&gt;)6&amp;21)%.M;76O&gt;#""9H.U=G&amp;D&gt;#"J&lt;A"5!0!!$!!$!!1!"1!'!!=!#!!*!!I!#Q!)!!Q!$1)!!(A!!!U)!!!*!!!!#1!!!)U,!!!*!!!!!!!!!!A!!!!)!!!!#!!!!!!!!!)1!!!!E!!!!!!"!!Y!!!!!</Property>
+			<Property Name="NI.ClassItem.ConnectorPane" Type="Bin">)!#!!!!!!!)!"1!&amp;!!!-!%!!!@````]!!!!"!!%!!!(8!!!!$Q!-1#%'=X2B&gt;(6T!!!,1!-!"'.P:'5!!""!-0````]'=W^V=G.F!!!71&amp;!!!Q!!!!%!!AFF=H*P=C"P&gt;81!$E!Q`````Q2C&lt;W2Z!!!11$$`````"WBF972F=H-!8%"Q!"Y!!$E;3&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1O&lt;(:M;7)=17*T&gt;(*B9X1A3&amp;255#"$&lt;'FF&lt;H1O&lt;(:D&lt;'&amp;T=Q!93&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1A&lt;X6U!!!21!=!#X.U982V=S"D&lt;W2F!!1!!!!61!-!$X2J&lt;76P&gt;81A+$%Q-$!Q+1!51$,`````#W^V&gt;("V&gt;#"G;7RF!#"!5!!$!!!!!1!#%W6S=G^S)'FO)#BO&lt;S"F=H*P=CE!$%!Q`````Q.V=GQ!7E"Q!"Y!!$E;3&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1O&lt;(:M;7)=17*T&gt;(*B9X1A3&amp;255#"$&lt;'FF&lt;H1O&lt;(:D&lt;'&amp;T=Q!83&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1A;7Y!6!$Q!!Q!!Q!%!!5!"A!(!!A!#1!+!!M!#!!-!!U#!!"Y!!!.#!!!#1!!!!E!!!#.#Q!!#1!!!!!!!!!)!!!!#!!!!!A!!!!!!!!#%!!!!*!!!!!!!1!/!!!!!!</Property>
 			<Property Name="NI.ClassItem.ExecutionSystem" Type="Int">-1</Property>
 			<Property Name="NI.ClassItem.Flags" Type="Int">16777344</Property>
 			<Property Name="NI.ClassItem.IsStaticMethod" Type="Bool">false</Property>
 			<Property Name="NI.ClassItem.MethodScope" Type="UInt">1</Property>
+			<Property Name="NI.ClassItem.MustOverride" Type="Bool">false</Property>
 			<Property Name="NI.ClassItem.Priority" Type="Int">1</Property>
-			<Property Name="NI.ClassItem.State" Type="Int">1342972416</Property>
+			<Property Name="NI.ClassItem.State" Type="Int">1082139136</Property>
 		</Item>
 		<Item Name="PUT File.vi" Type="VI" URL="../PUT File.vi">
-			<Property Name="NI.ClassItem.ConnectorPane" Type="Bin">)!#!!!!!!!)!"1!&amp;!!!-!%!!!@````]!!!!"!!%!!!(Z!!!!%!!-1#%'=X2B&gt;(6T!!!,1!-!"'.P:'5!!""!-0````]'=W^V=G.F!!!71&amp;!!!Q!!!!%!!AFF=H*P=C"P&gt;81!$E!Q`````Q2C&lt;W2Z!!!11$$`````"WBF972F=H-!:E"Q!"Y!!%-;3&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1O&lt;(:M;7)G17*T&gt;(*B9X1A3&amp;255#"$&lt;'FF&lt;H1A37ZU:8*G97.F,GRW9WRB=X-!'%B56&amp;!A1WRJ:7ZU)%&amp;C=X2S97.U)'^V&gt;!!!%5!(!!NT&gt;'&amp;U&gt;8-A9W^E:1!%!!!!&amp;5!$!!^U;7VF&lt;X6U)#AR-$!Q-#E!&amp;%!S`````QNP&gt;82Q&gt;81A:GFM:1!A1&amp;!!!Q!!!!%!!B.F=H*P=C"J&lt;C!I&lt;G]A:8*S&lt;X)J!!Z!-P````]%:GFM:1!!$%!Q`````Q.V=GQ!:%"Q!"Y!!%-;3&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1O&lt;(:M;7)G17*T&gt;(*B9X1A3&amp;255#"$&lt;'FF&lt;H1A37ZU:8*G97.F,GRW9WRB=X-!&amp;UB56&amp;!A1WRJ:7ZU)%&amp;C=X2S97.U)'FO!&amp;1!]!!-!!-!"!!&amp;!!9!"Q!)!!E!#A!,!!Q!$1!/!A!!?!!!$1A!!!E!!!!*!!!!D1M!!!E!!!!!!!!!#!!!!!A!!!!)!!!!#!!!!B!!!!#1!!!!!!%!$Q!!!!!</Property>
+			<Property Name="NI.ClassItem.ConnectorPane" Type="Bin">)!#!!!!!!!)!"1!&amp;!!!-!%!!!@````]!!!!"!!%!!!(F!!!!%!!-1#%'=X2B&gt;(6T!!!,1!-!"'.P:'5!!""!-0````]'=W^V=G.F!!!71&amp;!!!Q!!!!%!!AFF=H*P=C"P&gt;81!$E!Q`````Q2C&lt;W2Z!!!11$$`````"WBF972F=H-!8%"Q!"Y!!$E;3&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1O&lt;(:M;7)=17*T&gt;(*B9X1A3&amp;255#"$&lt;'FF&lt;H1O&lt;(:D&lt;'&amp;T=Q!93&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1A&lt;X6U!!!21!=!#X.U982V=S"D&lt;W2F!!1!!!!61!-!$X2J&lt;76P&gt;81A+$%Q-$!Q+1!51$,`````#W^V&gt;("V&gt;#"G;7RF!#"!5!!$!!!!!1!#%W6S=G^S)'FO)#BO&lt;S"F=H*P=CE!$E!S`````Q2G;7RF!!!-1$$`````!X6S&lt;!";1(!!(A!!/2J)6&amp;21)%.M;76O&gt;#""9H.U=G&amp;D&gt;#ZM&gt;GRJ9BR"9H.U=G&amp;D&gt;#")6&amp;21)%.M;76O&gt;#ZM&gt;G.M98.T!"&gt;)6&amp;21)%.M;76O&gt;#""9H.U=G&amp;D&gt;#"J&lt;A"5!0!!$!!$!!1!"1!'!!=!#!!*!!I!#Q!-!!U!$A)!!(A!!!U)!!!*!!!!#1!!!)U,!!!*!!!!!!!!!!A!!!!)!!!!#!!!!!A!!!)1!!!!E!!!!!!"!!]!!!!!</Property>
 			<Property Name="NI.ClassItem.ExecutionSystem" Type="Int">-1</Property>
 			<Property Name="NI.ClassItem.Flags" Type="Int">16777344</Property>
 			<Property Name="NI.ClassItem.IsStaticMethod" Type="Bool">false</Property>
 			<Property Name="NI.ClassItem.MethodScope" Type="UInt">1</Property>
+			<Property Name="NI.ClassItem.MustOverride" Type="Bool">false</Property>
 			<Property Name="NI.ClassItem.Priority" Type="Int">1</Property>
-			<Property Name="NI.ClassItem.State" Type="Int">1342972416</Property>
+			<Property Name="NI.ClassItem.State" Type="Int">1082139136</Property>
 		</Item>
 		<Item Name="PUT Buffer.vi" Type="VI" URL="../PUT Buffer.vi">
-			<Property Name="NI.ClassItem.ConnectorPane" Type="Bin">)!#!!!!!!!)!"1!&amp;!!!-!%!!!@````]!!!!"!!%!!!(\!!!!%!!-1#%'=X2B&gt;(6T!!!,1!-!"'.P:'5!!""!-0````]'=W^V=G.F!!!71&amp;!!!Q!!!!%!!AFF=H*P=C"P&gt;81!$E!Q`````Q2C&lt;W2Z!!!11$$`````"WBF972F=H-!:E"Q!"Y!!%-;3&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1O&lt;(:M;7)G17*T&gt;(*B9X1A3&amp;255#"$&lt;'FF&lt;H1A37ZU:8*G97.F,GRW9WRB=X-!'%B56&amp;!A1WRJ:7ZU)%&amp;C=X2S97.U)'^V&gt;!!!%5!(!!NT&gt;'&amp;U&gt;8-A9W^E:1!%!!!!&amp;5!$!!^U;7VF&lt;X6U)#AR-$!Q-#E!&amp;%!S`````QNP&gt;82Q&gt;81A:GFM:1!A1&amp;!!!Q!!!!%!!B.F=H*P=C"J&lt;C!I&lt;G]A:8*S&lt;X)J!""!-0````]'9H6G:G6S!!!-1$$`````!X6S&lt;!"E1(!!(A!!1RJ)6&amp;21)%.M;76O&gt;#""9H.U=G&amp;D&gt;#ZM&gt;GRJ9C:"9H.U=G&amp;D&gt;#")6&amp;21)%.M;76O&gt;#"*&lt;H2F=G:B9W5O&lt;(:D&lt;'&amp;T=Q!83&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1A;7Y!6!$Q!!Q!!Q!%!!5!"A!(!!A!#1!+!!M!$!!.!!Y#!!"Y!!!.#!!!#1!!!!E!!!#.#Q!!#1!!!!!!!!!)!!!!#!!!!!A!!!))!!!#%!!!!*!!!!!!!1!0!!!!!!</Property>
+			<Property Name="NI.ClassItem.ConnectorPane" Type="Bin">)!#!!!!!!!)!"1!&amp;!!!-!%!!!@````]!!!!"!!%!!!(H!!!!%!!-1#%'=X2B&gt;(6T!!!,1!-!"'.P:'5!!""!-0````]'=W^V=G.F!!!71&amp;!!!Q!!!!%!!AFF=H*P=C"P&gt;81!$E!Q`````Q2C&lt;W2Z!!!11$$`````"WBF972F=H-!8%"Q!"Y!!$E;3&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1O&lt;(:M;7)=17*T&gt;(*B9X1A3&amp;255#"$&lt;'FF&lt;H1O&lt;(:D&lt;'&amp;T=Q!93&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1A&lt;X6U!!!21!=!#X.U982V=S"D&lt;W2F!!1!!!!61!-!$X2J&lt;76P&gt;81A+$%Q-$!Q+1!51$,`````#W^V&gt;("V&gt;#"G;7RF!#"!5!!$!!!!!1!#%W6S=G^S)'FO)#BO&lt;S"F=H*P=CE!%%!Q`````Q:C&gt;7:G:8)!!!R!-0````]$&gt;8*M!&amp;J!=!!?!!!Z'EB56&amp;!A1WRJ:7ZU)%&amp;C=X2S97.U,GRW&lt;'FC(%&amp;C=X2S97.U)%B56&amp;!A1WRJ:7ZU,GRW9WRB=X-!&amp;UB56&amp;!A1WRJ:7ZU)%&amp;C=X2S97.U)'FO!&amp;1!]!!-!!-!"!!&amp;!!9!"Q!)!!E!#A!,!!Q!$1!/!A!!?!!!$1A!!!E!!!!*!!!!D1M!!!E!!!!!!!!!#!!!!!A!!!!)!!!##!!!!B!!!!#1!!!!!!%!$Q!!!!!</Property>
 			<Property Name="NI.ClassItem.ExecutionSystem" Type="Int">-1</Property>
 			<Property Name="NI.ClassItem.Flags" Type="Int">16777344</Property>
 			<Property Name="NI.ClassItem.IsStaticMethod" Type="Bool">false</Property>
 			<Property Name="NI.ClassItem.MethodScope" Type="UInt">1</Property>
+			<Property Name="NI.ClassItem.MustOverride" Type="Bool">false</Property>
 			<Property Name="NI.ClassItem.Priority" Type="Int">1</Property>
-			<Property Name="NI.ClassItem.State" Type="Int">1342972416</Property>
+			<Property Name="NI.ClassItem.State" Type="Int">1082139136</Property>
 		</Item>
 		<Item Name="POST Multipart.vi" Type="VI" URL="../POST Multipart.vi">
-			<Property Name="NI.ClassItem.ConnectorPane" Type="Bin">)!#!!!!!!!)!"1!&amp;!!!-!%!!!@````]!!!!"!!%!!!+:!!!!&amp;A!-1#%'=X2B&gt;(6T!!!,1!-!"'.P:'5!!""!-0````]'=W^V=G.F!!!71&amp;!!!Q!!!!%!!AFF=H*P=C"P&gt;81!$E!Q`````Q2C&lt;W2Z!!!11$$`````"WBF972F=H-!:E"Q!"Y!!%-;3&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1O&lt;(:M;7)G17*T&gt;(*B9X1A3&amp;255#"$&lt;'FF&lt;H1A37ZU:8*G97.F,GRW9WRB=X-!'%B56&amp;!A1WRJ:7ZU)%&amp;C=X2S97.U)'^V&gt;!!!%5!(!!NT&gt;'&amp;U&gt;8-A9W^E:1!%!!!!&amp;5!$!!^U;7VF&lt;X6U)#AR-$!Q-#E!&amp;%!S`````QNP&gt;82Q&gt;81A:GFM:1!A1&amp;!!!Q!!!!%!!B.F=H*P=C"J&lt;C!I&lt;G]A:8*S&lt;X)J!!Z!-0````]%4G&amp;N:1!!$E!Q`````Q6797RV:1!/1$,`````"%:J&lt;'5!!"*!-0````])2GFM:7ZB&lt;75!!"*!-0````]*45F.23"U?8"F!%Y!]1!!!!!!!!!#&amp;URB9F:*26&gt;)6&amp;211WRJ:7ZU,GRW&lt;'FC%5VV&lt;(2J='&amp;S&gt;%2B&gt;'%O9X2M!"R!5!!&amp;!!Q!$1!/!!]!%!&gt;&amp;&lt;'6N:7ZU!"*!1!!"`````Q!2"'2B&gt;'%!!!R!-0````]$&gt;8*M!'2!=!!?!!"$'EB56&amp;!A1WRJ:7ZU)%&amp;C=X2S97.U,GRW&lt;'FC*E&amp;C=X2S97.U)%B56&amp;!A1WRJ:7ZU)%FO&gt;'6S:G&amp;D:3ZM&gt;G.M98.T!"&gt;)6&amp;21)%.M;76O&gt;#""9H.U=G&amp;D&gt;#"J&lt;A"5!0!!$!!$!!1!"1!'!!=!#!!*!!I!#Q!3!"-!&amp;!)!!(A!!!U)!!!*!!!!#1!!!)U,!!!*!!!!!!!!!!A!!!!)!!!!#!!!!B!!!!)1!!!!E!!!!!!"!"5!!!!!</Property>
+			<Property Name="NI.ClassItem.ConnectorPane" Type="Bin">)!#!!!!!!!)!"1!&amp;!!!-!%!!!@````]!!!!"!!%!!!+&amp;!!!!&amp;A!-1#%'=X2B&gt;(6T!!!,1!-!"'.P:'5!!""!-0````]'=W^V=G.F!!!71&amp;!!!Q!!!!%!!AFF=H*P=C"P&gt;81!$E!Q`````Q2C&lt;W2Z!!!11$$`````"WBF972F=H-!8%"Q!"Y!!$E;3&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1O&lt;(:M;7)=17*T&gt;(*B9X1A3&amp;255#"$&lt;'FF&lt;H1O&lt;(:D&lt;'&amp;T=Q!93&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1A&lt;X6U!!!21!=!#X.U982V=S"D&lt;W2F!!1!!!!61!-!$X2J&lt;76P&gt;81A+$%Q-$!Q+1!51$,`````#W^V&gt;("V&gt;#"G;7RF!#"!5!!$!!!!!1!#%W6S=G^S)'FO)#BO&lt;S"F=H*P=CE!$E!Q`````Q2/97VF!!!/1$$`````"6:B&lt;(6F!!Z!-P````]%2GFM:1!!%E!Q`````QB';7RF&lt;G&amp;N:1!!%E!Q`````QF.35V&amp;)(2Z='5!4A$R!!!!!!!!!!)84'&amp;C6EF&amp;6UB56&amp;"$&lt;'FF&lt;H1O&lt;(:M;7)2486M&gt;'FQ98*U2'&amp;U93ZD&gt;'Q!(%"1!!5!$!!.!!Y!$Q!1"U6M:7VF&lt;H1!%E"!!!(`````!"%%:'&amp;U91!!$%!Q`````Q.V=GQ!7E"Q!"Y!!$E;3&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1O&lt;(:M;7)=17*T&gt;(*B9X1A3&amp;255#"$&lt;'FF&lt;H1O&lt;(:D&lt;'&amp;T=Q!83&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1A;7Y!6!$Q!!Q!!Q!%!!5!"A!(!!A!#1!+!!M!%A!4!"1#!!"Y!!!.#!!!#1!!!!E!!!#.#Q!!#1!!!!!!!!!)!!!!#!!!!!A!!!)1!!!#%!!!!*!!!!!!!1!6!!!!!!</Property>
 			<Property Name="NI.ClassItem.ExecutionSystem" Type="Int">-1</Property>
 			<Property Name="NI.ClassItem.Flags" Type="Int">16777344</Property>
 			<Property Name="NI.ClassItem.IsStaticMethod" Type="Bool">false</Property>
 			<Property Name="NI.ClassItem.MethodScope" Type="UInt">1</Property>
+			<Property Name="NI.ClassItem.MustOverride" Type="Bool">false</Property>
 			<Property Name="NI.ClassItem.Priority" Type="Int">1</Property>
-			<Property Name="NI.ClassItem.State" Type="Int">1342972416</Property>
+			<Property Name="NI.ClassItem.State" Type="Int">1082139136</Property>
 		</Item>
 		<Item Name="POST File.vi" Type="VI" URL="../POST File.vi">
-			<Property Name="NI.ClassItem.ConnectorPane" Type="Bin">)!#!!!!!!!)!"1!&amp;!!!-!%!!!@````]!!!!"!!%!!!(Z!!!!%!!-1#%'=X2B&gt;(6T!!!,1!-!"'.P:'5!!""!-0````]'=W^V=G.F!!!71&amp;!!!Q!!!!%!!AFF=H*P=C"P&gt;81!$E!Q`````Q2C&lt;W2Z!!!11$$`````"WBF972F=H-!:E"Q!"Y!!%-;3&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1O&lt;(:M;7)G17*T&gt;(*B9X1A3&amp;255#"$&lt;'FF&lt;H1A37ZU:8*G97.F,GRW9WRB=X-!'%B56&amp;!A1WRJ:7ZU)%&amp;C=X2S97.U)'^V&gt;!!!%5!(!!NT&gt;'&amp;U&gt;8-A9W^E:1!%!!!!&amp;5!$!!^U;7VF&lt;X6U)#AR-$!Q-#E!&amp;%!S`````QNP&gt;82Q&gt;81A:GFM:1!A1&amp;!!!Q!!!!%!!B.F=H*P=C"J&lt;C!I&lt;G]A:8*S&lt;X)J!!Z!-P````]%:GFM:1!!$%!Q`````Q.V=GQ!:%"Q!"Y!!%-;3&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1O&lt;(:M;7)G17*T&gt;(*B9X1A3&amp;255#"$&lt;'FF&lt;H1A37ZU:8*G97.F,GRW9WRB=X-!&amp;UB56&amp;!A1WRJ:7ZU)%&amp;C=X2S97.U)'FO!&amp;1!]!!-!!-!"!!&amp;!!9!"Q!)!!E!#A!,!!Q!$1!/!A!!?!!!$1A!!!E!!!!*!!!!D1M!!!E!!!!!!!!!#!!!!!A!!!!)!!!!#!!!!B!!!!#1!!!!!!%!$Q!!!!!</Property>
+			<Property Name="NI.ClassItem.ConnectorPane" Type="Bin">)!#!!!!!!!)!"1!&amp;!!!-!%!!!@````]!!!!"!!%!!!(F!!!!%!!-1#%'=X2B&gt;(6T!!!,1!-!"'.P:'5!!""!-0````]'=W^V=G.F!!!71&amp;!!!Q!!!!%!!AFF=H*P=C"P&gt;81!$E!Q`````Q2C&lt;W2Z!!!11$$`````"WBF972F=H-!8%"Q!"Y!!$E;3&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1O&lt;(:M;7)=17*T&gt;(*B9X1A3&amp;255#"$&lt;'FF&lt;H1O&lt;(:D&lt;'&amp;T=Q!93&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1A&lt;X6U!!!21!=!#X.U982V=S"D&lt;W2F!!1!!!!61!-!$X2J&lt;76P&gt;81A+$%Q-$!Q+1!51$,`````#W^V&gt;("V&gt;#"G;7RF!#"!5!!$!!!!!1!#%W6S=G^S)'FO)#BO&lt;S"F=H*P=CE!$E!S`````Q2G;7RF!!!-1$$`````!X6S&lt;!";1(!!(A!!/2J)6&amp;21)%.M;76O&gt;#""9H.U=G&amp;D&gt;#ZM&gt;GRJ9BR"9H.U=G&amp;D&gt;#")6&amp;21)%.M;76O&gt;#ZM&gt;G.M98.T!"&gt;)6&amp;21)%.M;76O&gt;#""9H.U=G&amp;D&gt;#"J&lt;A"5!0!!$!!$!!1!"1!'!!=!#!!*!!I!#Q!-!!U!$A)!!(A!!!U)!!!*!!!!#1!!!)U,!!!*!!!!!!!!!!A!!!!)!!!!#!!!!!A!!!)1!!!!E!!!!!!"!!]!!!!!</Property>
 			<Property Name="NI.ClassItem.ExecutionSystem" Type="Int">-1</Property>
 			<Property Name="NI.ClassItem.Flags" Type="Int">16777344</Property>
 			<Property Name="NI.ClassItem.IsStaticMethod" Type="Bool">false</Property>
 			<Property Name="NI.ClassItem.MethodScope" Type="UInt">1</Property>
+			<Property Name="NI.ClassItem.MustOverride" Type="Bool">false</Property>
 			<Property Name="NI.ClassItem.Priority" Type="Int">1</Property>
-			<Property Name="NI.ClassItem.State" Type="Int">1342972416</Property>
+			<Property Name="NI.ClassItem.State" Type="Int">1082139136</Property>
 		</Item>
 		<Item Name="POST Buffer.vi" Type="VI" URL="../POST Buffer.vi">
-			<Property Name="NI.ClassItem.ConnectorPane" Type="Bin">)!#!!!!!!!)!"1!&amp;!!!-!%!!!@````]!!!!"!!%!!!(\!!!!%!!-1#%'=X2B&gt;(6T!!!,1!-!"'.P:'5!!""!-0````]'=W^V=G.F!!!71&amp;!!!Q!!!!%!!AFF=H*P=C"P&gt;81!$E!Q`````Q2C&lt;W2Z!!!11$$`````"WBF972F=H-!:E"Q!"Y!!%-;3&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1O&lt;(:M;7)G17*T&gt;(*B9X1A3&amp;255#"$&lt;'FF&lt;H1A37ZU:8*G97.F,GRW9WRB=X-!'%B56&amp;!A1WRJ:7ZU)%&amp;C=X2S97.U)'^V&gt;!!!%5!(!!NT&gt;'&amp;U&gt;8-A9W^E:1!%!!!!&amp;5!$!!^U;7VF&lt;X6U)#AR-$!Q-#E!&amp;%!S`````QNP&gt;82Q&gt;81A:GFM:1!A1&amp;!!!Q!!!!%!!B.F=H*P=C"J&lt;C!I&lt;G]A:8*S&lt;X)J!""!-0````]'9H6G:G6S!!!-1$$`````!X6S&lt;!"E1(!!(A!!1RJ)6&amp;21)%.M;76O&gt;#""9H.U=G&amp;D&gt;#ZM&gt;GRJ9C:"9H.U=G&amp;D&gt;#")6&amp;21)%.M;76O&gt;#"*&lt;H2F=G:B9W5O&lt;(:D&lt;'&amp;T=Q!83&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1A;7Y!6!$Q!!Q!!Q!%!!5!"A!(!!A!#1!+!!M!$!!.!!Y#!!"Y!!!.#!!!#1!!!!E!!!#.#Q!!#1!!!!!!!!!)!!!!#!!!!!A!!!))!!!#%!!!!*!!!!!!!1!0!!!!!!</Property>
+			<Property Name="NI.ClassItem.ConnectorPane" Type="Bin">)!#!!!!!!!)!"1!&amp;!!!-!%!!!@````]!!!!"!!%!!!(H!!!!%!!-1#%'=X2B&gt;(6T!!!,1!-!"'.P:'5!!""!-0````]'=W^V=G.F!!!71&amp;!!!Q!!!!%!!AFF=H*P=C"P&gt;81!$E!Q`````Q2C&lt;W2Z!!!11$$`````"WBF972F=H-!8%"Q!"Y!!$E;3&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1O&lt;(:M;7)=17*T&gt;(*B9X1A3&amp;255#"$&lt;'FF&lt;H1O&lt;(:D&lt;'&amp;T=Q!93&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1A&lt;X6U!!!21!=!#X.U982V=S"D&lt;W2F!!1!!!!61!-!$X2J&lt;76P&gt;81A+$%Q-$!Q+1!51$,`````#W^V&gt;("V&gt;#"G;7RF!#"!5!!$!!!!!1!#%W6S=G^S)'FO)#BO&lt;S"F=H*P=CE!%%!Q`````Q:C&gt;7:G:8)!!!R!-0````]$&gt;8*M!&amp;J!=!!?!!!Z'EB56&amp;!A1WRJ:7ZU)%&amp;C=X2S97.U,GRW&lt;'FC(%&amp;C=X2S97.U)%B56&amp;!A1WRJ:7ZU,GRW9WRB=X-!&amp;UB56&amp;!A1WRJ:7ZU)%&amp;C=X2S97.U)'FO!&amp;1!]!!-!!-!"!!&amp;!!9!"Q!)!!E!#A!,!!Q!$1!/!A!!?!!!$1A!!!E!!!!*!!!!D1M!!!E!!!!!!!!!#!!!!!A!!!!)!!!##!!!!B!!!!#1!!!!!!%!$Q!!!!!</Property>
 			<Property Name="NI.ClassItem.ExecutionSystem" Type="Int">-1</Property>
 			<Property Name="NI.ClassItem.Flags" Type="Int">16777344</Property>
 			<Property Name="NI.ClassItem.IsStaticMethod" Type="Bool">false</Property>
 			<Property Name="NI.ClassItem.MethodScope" Type="UInt">1</Property>
+			<Property Name="NI.ClassItem.MustOverride" Type="Bool">false</Property>
 			<Property Name="NI.ClassItem.Priority" Type="Int">1</Property>
-			<Property Name="NI.ClassItem.State" Type="Int">1342972416</Property>
+			<Property Name="NI.ClassItem.State" Type="Int">1082139136</Property>
 		</Item>
 		<Item Name="HEAD.vi" Type="VI" URL="../HEAD.vi">
-			<Property Name="NI.ClassItem.ConnectorPane" Type="Bin">)!#!!!!!!!)!"1!&amp;!!!-!%!!!@````]!!!!"!!%!!!(*!!!!$1!-1#%'=X2B&gt;(6T!!!,1!-!"'.P:'5!!""!-0````]'=W^V=G.F!!!71&amp;!!!Q!!!!%!!AFF=H*P=C"P&gt;81!"!!!!""!-0````](;'6B:'6S=Q"G1(!!(A!!1RJ)6&amp;21)%.M;76O&gt;#""9H.U=G&amp;D&gt;#ZM&gt;GRJ9C:"9H.U=G&amp;D&gt;#")6&amp;21)%.M;76O&gt;#"*&lt;H2F=G:B9W5O&lt;(:D&lt;'&amp;T=Q!93&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1A&lt;X6U!!!21!=!#X.U982V=S"D&lt;W2F!"6!!Q!0&gt;'FN:7^V&gt;#!I-4!Q-$!J!#"!5!!$!!!!!1!#%W6S=G^S)'FO)#BO&lt;S"F=H*P=CE!$%!Q`````Q.V=GQ!:%"Q!"Y!!%-;3&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1O&lt;(:M;7)G17*T&gt;(*B9X1A3&amp;255#"$&lt;'FF&lt;H1A37ZU:8*G97.F,GRW9WRB=X-!&amp;UB56&amp;!A1WRJ:7ZU)%&amp;C=X2S97.U)'FO!&amp;1!]!!-!!-!"!!&amp;!!9!"Q!%!!A!"!!*!!1!#A!,!A!!?!!!$1A!!!!!!!!*!!!!D1M!!!E!!!!!!!!!#!!!!!!!!!!)!!!!!!!!!B!!!!#1!!!!!!%!$!!!!!!</Property>
+			<Property Name="NI.ClassItem.ConnectorPane" Type="Bin">)!#!!!!!!!)!"1!&amp;!!!-!%!!!@````]!!!!"!!%!!!'V!!!!$1!-1#%'=X2B&gt;(6T!!!,1!-!"'.P:'5!!""!-0````]'=W^V=G.F!!!71&amp;!!!Q!!!!%!!AFF=H*P=C"P&gt;81!"!!!!""!-0````](;'6B:'6S=Q"=1(!!(A!!/2J)6&amp;21)%.M;76O&gt;#""9H.U=G&amp;D&gt;#ZM&gt;GRJ9BR"9H.U=G&amp;D&gt;#")6&amp;21)%.M;76O&gt;#ZM&gt;G.M98.T!"B)6&amp;21)%.M;76O&gt;#""9H.U=G&amp;D&gt;#"P&gt;81!!"&amp;!"Q!,=X2B&gt;(6T)'.P:'5!&amp;5!$!!^U;7VF&lt;X6U)#AR-$!Q-#E!)%"1!!-!!!!"!!)4:8*S&lt;X)A;7YA+'ZP)'6S=G^S+1!-1$$`````!X6S&lt;!";1(!!(A!!/2J)6&amp;21)%.M;76O&gt;#""9H.U=G&amp;D&gt;#ZM&gt;GRJ9BR"9H.U=G&amp;D&gt;#")6&amp;21)%.M;76O&gt;#ZM&gt;G.M98.T!"&gt;)6&amp;21)%.M;76O&gt;#""9H.U=G&amp;D&gt;#"J&lt;A"5!0!!$!!$!!1!"1!'!!=!"!!)!!1!#1!%!!I!#Q)!!(A!!!U)!!!!!!!!#1!!!)U,!!!*!!!!!!!!!!A!!!!!!!!!#!!!!!!!!!)1!!!!E!!!!!!"!!Q!!!!!</Property>
 			<Property Name="NI.ClassItem.ExecutionSystem" Type="Int">-1</Property>
 			<Property Name="NI.ClassItem.Flags" Type="Int">16777344</Property>
 			<Property Name="NI.ClassItem.IsStaticMethod" Type="Bool">false</Property>
 			<Property Name="NI.ClassItem.MethodScope" Type="UInt">1</Property>
+			<Property Name="NI.ClassItem.MustOverride" Type="Bool">false</Property>
 			<Property Name="NI.ClassItem.Priority" Type="Int">1</Property>
-			<Property Name="NI.ClassItem.State" Type="Int">1342972416</Property>
+			<Property Name="NI.ClassItem.State" Type="Int">1082139136</Property>
 		</Item>
 		<Item Name="GET.vi" Type="VI" URL="../GET.vi">
-			<Property Name="NI.ClassItem.ConnectorPane" Type="Bin">)!#!!!!!!!)!"1!&amp;!!!-!%!!!@````]!!!!"!!%!!!(L!!!!$Q!-1#%'=X2B&gt;(6T!!!,1!-!"'.P:'5!!""!-0````]'=W^V=G.F!!!71&amp;!!!Q!!!!%!!AFF=H*P=C"P&gt;81!$E!Q`````Q2C&lt;W2Z!!!11$$`````"WBF972F=H-!:E"Q!"Y!!%-;3&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1O&lt;(:M;7)G17*T&gt;(*B9X1A3&amp;255#"$&lt;'FF&lt;H1A37ZU:8*G97.F,GRW9WRB=X-!'%B56&amp;!A1WRJ:7ZU)%&amp;C=X2S97.U)'^V&gt;!!!%5!(!!NT&gt;'&amp;U&gt;8-A9W^E:1!%!!!!&amp;5!$!!^U;7VF&lt;X6U)#AR-$!Q-#E!&amp;%!S`````QNP&gt;82Q&gt;81A:GFM:1!A1&amp;!!!Q!!!!%!!B.F=H*P=C"J&lt;C!I&lt;G]A:8*S&lt;X)J!!R!-0````]$&gt;8*M!'2!=!!?!!"$'EB56&amp;!A1WRJ:7ZU)%&amp;C=X2S97.U,GRW&lt;'FC*E&amp;C=X2S97.U)%B56&amp;!A1WRJ:7ZU)%FO&gt;'6S:G&amp;D:3ZM&gt;G.M98.T!"&gt;)6&amp;21)%.M;76O&gt;#""9H.U=G&amp;D&gt;#"J&lt;A"5!0!!$!!$!!1!"1!'!!=!#!!*!!I!#Q!)!!Q!$1)!!(A!!!U)!!!*!!!!#1!!!)U,!!!*!!!!!!!!!!A!!!!)!!!!#!!!!!!!!!)1!!!!E!!!!!!"!!Y!!!!!</Property>
+			<Property Name="NI.ClassItem.ConnectorPane" Type="Bin">)!#!!!!!!!)!"1!&amp;!!!-!%!!!@````]!!!!"!!%!!!(8!!!!$Q!-1#%'=X2B&gt;(6T!!!,1!-!"'.P:'5!!""!-0````]'=W^V=G.F!!!71&amp;!!!Q!!!!%!!AFF=H*P=C"P&gt;81!$E!Q`````Q2C&lt;W2Z!!!11$$`````"WBF972F=H-!8%"Q!"Y!!$E;3&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1O&lt;(:M;7)=17*T&gt;(*B9X1A3&amp;255#"$&lt;'FF&lt;H1O&lt;(:D&lt;'&amp;T=Q!93&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1A&lt;X6U!!!21!=!#X.U982V=S"D&lt;W2F!!1!!!!61!-!$X2J&lt;76P&gt;81A+$%Q-$!Q+1!51$,`````#W^V&gt;("V&gt;#"G;7RF!#"!5!!$!!!!!1!#%W6S=G^S)'FO)#BO&lt;S"F=H*P=CE!$%!Q`````Q.V=GQ!7E"Q!"Y!!$E;3&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1O&lt;(:M;7)=17*T&gt;(*B9X1A3&amp;255#"$&lt;'FF&lt;H1O&lt;(:D&lt;'&amp;T=Q!83&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1A;7Y!6!$Q!!Q!!Q!%!!5!"A!(!!A!#1!+!!M!#!!-!!U#!!"Y!!!.#!!!#1!!!!E!!!#.#Q!!#1!!!!!!!!!)!!!!#!!!!!A!!!!!!!!#%!!!!*!!!!!!!1!/!!!!!!</Property>
 			<Property Name="NI.ClassItem.ExecutionSystem" Type="Int">-1</Property>
 			<Property Name="NI.ClassItem.Flags" Type="Int">16777344</Property>
 			<Property Name="NI.ClassItem.IsStaticMethod" Type="Bool">false</Property>
 			<Property Name="NI.ClassItem.MethodScope" Type="UInt">1</Property>
+			<Property Name="NI.ClassItem.MustOverride" Type="Bool">false</Property>
 			<Property Name="NI.ClassItem.Priority" Type="Int">1</Property>
-			<Property Name="NI.ClassItem.State" Type="Int">1342972416</Property>
+			<Property Name="NI.ClassItem.State" Type="Int">1082139136</Property>
 		</Item>
 		<Item Name="Add Header.vi" Type="VI" URL="../Add Header.vi">
-			<Property Name="NI.ClassItem.ConnectorPane" Type="Bin">)!#!!!!!!!)!"1!&amp;!!!-!%!!!@````]!!!!"!!%!!!'F!!!!#Q!-1#%'=X2B&gt;(6T!!!,1!-!"'.P:'5!!""!-0````]'=W^V=G.F!!!71&amp;!!!Q!!!!%!!AFF=H*P=C"P&gt;81!"!!!!':!=!!?!!"$'EB56&amp;!A1WRJ:7ZU)%&amp;C=X2S97.U,GRW&lt;'FC*E&amp;C=X2S97.U)%B56&amp;!A1WRJ:7ZU)%FO&gt;'6S:G&amp;D:3ZM&gt;G.M98.T!"B)6&amp;21)%.M;76O&gt;#""9H.U=G&amp;D&gt;#"P&gt;81!!#"!5!!$!!!!!1!#%W6S=G^S)'FO)#BO&lt;S"F=H*P=CE!$E!Q`````Q6W97RV:1!11$$`````"GBF972F=A!!:%"Q!"Y!!%-;3&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1O&lt;(:M;7)G17*T&gt;(*B9X1A3&amp;255#"$&lt;'FF&lt;H1A37ZU:8*G97.F,GRW9WRB=X-!&amp;UB56&amp;!A1WRJ:7ZU)%&amp;C=X2S97.U)'FO!&amp;1!]!!-!!-!"!!%!!5!"!!%!!1!"!!'!!=!#!!*!A!!?!!!$1A!!!!!!!!!!!!!D1M!!!!!!!!!!!!!!!!!!!!!!!!)!!!##!!!!AA!!!#1!!!!!!%!#A!!!!!</Property>
+			<Property Name="NI.ClassItem.ConnectorPane" Type="Bin">)!#!!!!!!!)!"1!&amp;!!!-!%!!!@````]!!!!"!!%!!!'2!!!!#Q!-1#%'=X2B&gt;(6T!!!,1!-!"'.P:'5!!""!-0````]'=W^V=G.F!!!71&amp;!!!Q!!!!%!!AFF=H*P=C"P&gt;81!"!!!!&amp;R!=!!?!!!Z'EB56&amp;!A1WRJ:7ZU)%&amp;C=X2S97.U,GRW&lt;'FC(%&amp;C=X2S97.U)%B56&amp;!A1WRJ:7ZU,GRW9WRB=X-!'%B56&amp;!A1WRJ:7ZU)%&amp;C=X2S97.U)'^V&gt;!!!)%"1!!-!!!!"!!)4:8*S&lt;X)A;7YA+'ZP)'6S=G^S+1!/1$$`````"8:B&lt;(6F!""!-0````]';'6B:'6S!!";1(!!(A!!/2J)6&amp;21)%.M;76O&gt;#""9H.U=G&amp;D&gt;#ZM&gt;GRJ9BR"9H.U=G&amp;D&gt;#")6&amp;21)%.M;76O&gt;#ZM&gt;G.M98.T!"&gt;)6&amp;21)%.M;76O&gt;#""9H.U=G&amp;D&gt;#"J&lt;A"5!0!!$!!$!!1!"!!&amp;!!1!"!!%!!1!"A!(!!A!#1)!!(A!!!U)!!!!!!!!!!!!!)U,!!!!!!!!!!!!!!!!!!!!!!!!#!!!!AA!!!))!!!!E!!!!!!"!!I!!!!!</Property>
 			<Property Name="NI.ClassItem.ExecutionSystem" Type="Int">-1</Property>
 			<Property Name="NI.ClassItem.Flags" Type="Int">16777344</Property>
 			<Property Name="NI.ClassItem.IsStaticMethod" Type="Bool">false</Property>
 			<Property Name="NI.ClassItem.MethodScope" Type="UInt">1</Property>
+			<Property Name="NI.ClassItem.MustOverride" Type="Bool">false</Property>
 			<Property Name="NI.ClassItem.Priority" Type="Int">1</Property>
-			<Property Name="NI.ClassItem.State" Type="Int">1342972416</Property>
+			<Property Name="NI.ClassItem.State" Type="Int">1082139136</Property>
 		</Item>
 		<Item Name="Get Header.vi" Type="VI" URL="../Get Header.vi">
-			<Property Name="NI.ClassItem.ConnectorPane" Type="Bin">)!#!!!!!!!)!"1!&amp;!!!-!%!!!@````]!!!!"!!%!!!'F!!!!#Q!-1#%'=X2B&gt;(6T!!!,1!-!"'.P:'5!!""!-0````]'=W^V=G.F!!!71&amp;!!!Q!!!!%!!AFF=H*P=C"P&gt;81!"!!!!!Z!-0````]&amp;&gt;G&amp;M&gt;75!:E"Q!"Y!!%-;3&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1O&lt;(:M;7)G17*T&gt;(*B9X1A3&amp;255#"$&lt;'FF&lt;H1A37ZU:8*G97.F,GRW9WRB=X-!'%B56&amp;!A1WRJ:7ZU)%&amp;C=X2S97.U)'^V&gt;!!!)%"1!!-!!!!"!!)4:8*S&lt;X)A;7YA+'ZP)'6S=G^S+1!11$$`````"GBF972F=A!!:%"Q!"Y!!%-;3&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1O&lt;(:M;7)G17*T&gt;(*B9X1A3&amp;255#"$&lt;'FF&lt;H1A37ZU:8*G97.F,GRW9WRB=X-!&amp;UB56&amp;!A1WRJ:7ZU)%&amp;C=X2S97.U)'FO!&amp;1!]!!-!!-!"!!&amp;!!9!"!!%!!1!"!!(!!1!#!!*!A!!?!!!$1A!!!!!!!!*!!!!D1M!!!!!!!!!!!!!!!!!!!!!!!!)!!!!!!!!!AA!!!#1!!!!!!%!#A!!!!!</Property>
+			<Property Name="NI.ClassItem.ConnectorPane" Type="Bin">)!#!!!!!!!)!"1!&amp;!!!-!%!!!@````]!!!!"!!%!!!'2!!!!#Q!-1#%'=X2B&gt;(6T!!!,1!-!"'.P:'5!!""!-0````]'=W^V=G.F!!!71&amp;!!!Q!!!!%!!AFF=H*P=C"P&gt;81!"!!!!!Z!-0````]&amp;&gt;G&amp;M&gt;75!8%"Q!"Y!!$E;3&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1O&lt;(:M;7)=17*T&gt;(*B9X1A3&amp;255#"$&lt;'FF&lt;H1O&lt;(:D&lt;'&amp;T=Q!93&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1A&lt;X6U!!!A1&amp;!!!Q!!!!%!!B.F=H*P=C"J&lt;C!I&lt;G]A:8*S&lt;X)J!""!-0````]';'6B:'6S!!";1(!!(A!!/2J)6&amp;21)%.M;76O&gt;#""9H.U=G&amp;D&gt;#ZM&gt;GRJ9BR"9H.U=G&amp;D&gt;#")6&amp;21)%.M;76O&gt;#ZM&gt;G.M98.T!"&gt;)6&amp;21)%.M;76O&gt;#""9H.U=G&amp;D&gt;#"J&lt;A"5!0!!$!!$!!1!"1!'!!1!"!!%!!1!"Q!%!!A!#1)!!(A!!!U)!!!!!!!!#1!!!)U,!!!!!!!!!!!!!!!!!!!!!!!!#!!!!!!!!!))!!!!E!!!!!!"!!I!!!!!</Property>
 			<Property Name="NI.ClassItem.ExecutionSystem" Type="Int">-1</Property>
 			<Property Name="NI.ClassItem.Flags" Type="Int">16777344</Property>
 			<Property Name="NI.ClassItem.IsStaticMethod" Type="Bool">false</Property>
 			<Property Name="NI.ClassItem.MethodScope" Type="UInt">1</Property>
+			<Property Name="NI.ClassItem.MustOverride" Type="Bool">false</Property>
 			<Property Name="NI.ClassItem.Priority" Type="Int">1</Property>
-			<Property Name="NI.ClassItem.State" Type="Int">1342972416</Property>
+			<Property Name="NI.ClassItem.State" Type="Int">1082139136</Property>
 		</Item>
 		<Item Name="Header Exists.vi" Type="VI" URL="../Header Exists.vi">
-			<Property Name="NI.ClassItem.ConnectorPane" Type="Bin">)!#!!!!!!!)!"1!&amp;!!!-!%!!!@````]!!!!"!!%!!!'Z!!!!$!!-1#%'=X2B&gt;(6T!!!,1!-!"'.P:'5!!""!-0````]'=W^V=G.F!!!71&amp;!!!Q!!!!%!!AFF=H*P=C"P&gt;81!$E!Q`````Q6W97RV:1!51#%/;'6B:'6S)'6Y;8.U=T]!!':!=!!?!!"$'EB56&amp;!A1WRJ:7ZU)%&amp;C=X2S97.U,GRW&lt;'FC*E&amp;C=X2S97.U)%B56&amp;!A1WRJ:7ZU)%FO&gt;'6S:G&amp;D:3ZM&gt;G.M98.T!"B)6&amp;21)%.M;76O&gt;#""9H.U=G&amp;D&gt;#"P&gt;81!!!1!!!!A1&amp;!!!Q!!!!%!!B.F=H*P=C"J&lt;C!I&lt;G]A:8*S&lt;X)J!""!-0````]';'6B:'6S!!"E1(!!(A!!1RJ)6&amp;21)%.M;76O&gt;#""9H.U=G&amp;D&gt;#ZM&gt;GRJ9C:"9H.U=G&amp;D&gt;#")6&amp;21)%.M;76O&gt;#"*&lt;H2F=G:B9W5O&lt;(:D&lt;'&amp;T=Q!83&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1A;7Y!6!$Q!!Q!!Q!%!!5!"A!(!!=!"Q!(!!A!"Q!*!!I#!!"Y!!!.#!!!#1!!!!E!!!#.#Q!!!!!!!!!!!!!!!!!!!!!!!!A!!!!!!!!##!!!!*!!!!!!!1!,!!!!!!</Property>
+			<Property Name="NI.ClassItem.ConnectorPane" Type="Bin">)!#!!!!!!!)!"1!&amp;!!!-!%!!!@````]!!!!"!!%!!!'F!!!!$!!-1#%'=X2B&gt;(6T!!!,1!-!"'.P:'5!!""!-0````]'=W^V=G.F!!!71&amp;!!!Q!!!!%!!AFF=H*P=C"P&gt;81!$E!Q`````Q6W97RV:1!51#%/;'6B:'6S)'6Y;8.U=T]!!&amp;R!=!!?!!!Z'EB56&amp;!A1WRJ:7ZU)%&amp;C=X2S97.U,GRW&lt;'FC(%&amp;C=X2S97.U)%B56&amp;!A1WRJ:7ZU,GRW9WRB=X-!'%B56&amp;!A1WRJ:7ZU)%&amp;C=X2S97.U)'^V&gt;!!!"!!!!#"!5!!$!!!!!1!#%W6S=G^S)'FO)#BO&lt;S"F=H*P=CE!%%!Q`````Q:I:7&amp;E:8)!!&amp;J!=!!?!!!Z'EB56&amp;!A1WRJ:7ZU)%&amp;C=X2S97.U,GRW&lt;'FC(%&amp;C=X2S97.U)%B56&amp;!A1WRJ:7ZU,GRW9WRB=X-!&amp;UB56&amp;!A1WRJ:7ZU)%&amp;C=X2S97.U)'FO!&amp;1!]!!-!!-!"!!&amp;!!9!"Q!(!!=!"Q!)!!=!#1!+!A!!?!!!$1A!!!E!!!!*!!!!D1M!!!!!!!!!!!!!!!!!!!!!!!!)!!!!!!!!!AA!!!#1!!!!!!%!#Q!!!!!</Property>
 			<Property Name="NI.ClassItem.ExecutionSystem" Type="Int">-1</Property>
 			<Property Name="NI.ClassItem.Flags" Type="Int">0</Property>
 			<Property Name="NI.ClassItem.IsStaticMethod" Type="Bool">false</Property>
 			<Property Name="NI.ClassItem.MethodScope" Type="UInt">1</Property>
+			<Property Name="NI.ClassItem.MustOverride" Type="Bool">false</Property>
 			<Property Name="NI.ClassItem.Priority" Type="Int">1</Property>
-			<Property Name="NI.ClassItem.State" Type="Int">1342972416</Property>
+			<Property Name="NI.ClassItem.State" Type="Int">1082139136</Property>
 		</Item>
 		<Item Name="List Headers.vi" Type="VI" URL="../List Headers.vi">
-			<Property Name="NI.ClassItem.ConnectorPane" Type="Bin">)!#!!!!!!!)!"1!&amp;!!!-!%!!!@````]!!!!"!!%!!!'8!!!!#A!-1#%'=X2B&gt;(6T!!!,1!-!"'.P:'5!!""!-0````]'=W^V=G.F!!!71&amp;!!!Q!!!!%!!AFF=H*P=C"P&gt;81!"!!!!""!-0````](;'6B:'6S=Q"G1(!!(A!!1RJ)6&amp;21)%.M;76O&gt;#""9H.U=G&amp;D&gt;#ZM&gt;GRJ9C:"9H.U=G&amp;D&gt;#")6&amp;21)%.M;76O&gt;#"*&lt;H2F=G:B9W5O&lt;(:D&lt;'&amp;T=Q!93&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1A&lt;X6U!!!A1&amp;!!!Q!!!!%!!B.F=H*P=C"J&lt;C!I&lt;G]A:8*S&lt;X)J!'2!=!!?!!"$'EB56&amp;!A1WRJ:7ZU)%&amp;C=X2S97.U,GRW&lt;'FC*E&amp;C=X2S97.U)%B56&amp;!A1WRJ:7ZU)%FO&gt;'6S:G&amp;D:3ZM&gt;G.M98.T!"&gt;)6&amp;21)%.M;76O&gt;#""9H.U=G&amp;D&gt;#"J&lt;A"5!0!!$!!$!!1!"1!'!!1!"!!%!!1!"Q!%!!1!#!)!!(A!!!U)!!!!!!!!#1!!!)U,!!!!!!!!!!!!!!!!!!!!!!!!#!!!!!!!!!!!!!!!E!!!!!!"!!E!!!!!</Property>
+			<Property Name="NI.ClassItem.ConnectorPane" Type="Bin">)!#!!!!!!!)!"1!&amp;!!!-!%!!!@````]!!!!"!!%!!!'$!!!!#A!-1#%'=X2B&gt;(6T!!!,1!-!"'.P:'5!!""!-0````]'=W^V=G.F!!!71&amp;!!!Q!!!!%!!AFF=H*P=C"P&gt;81!"!!!!""!-0````](;'6B:'6S=Q"=1(!!(A!!/2J)6&amp;21)%.M;76O&gt;#""9H.U=G&amp;D&gt;#ZM&gt;GRJ9BR"9H.U=G&amp;D&gt;#")6&amp;21)%.M;76O&gt;#ZM&gt;G.M98.T!"B)6&amp;21)%.M;76O&gt;#""9H.U=G&amp;D&gt;#"P&gt;81!!#"!5!!$!!!!!1!#%W6S=G^S)'FO)#BO&lt;S"F=H*P=CE!7E"Q!"Y!!$E;3&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1O&lt;(:M;7)=17*T&gt;(*B9X1A3&amp;255#"$&lt;'FF&lt;H1O&lt;(:D&lt;'&amp;T=Q!83&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1A;7Y!6!$Q!!Q!!Q!%!!5!"A!%!!1!"!!%!!=!"!!%!!A#!!"Y!!!.#!!!!!!!!!E!!!#.#Q!!!!!!!!!!!!!!!!!!!!!!!!A!!!!!!!!!!!!!!*!!!!!!!1!*!!!!!!</Property>
 			<Property Name="NI.ClassItem.ExecutionSystem" Type="Int">-1</Property>
 			<Property Name="NI.ClassItem.Flags" Type="Int">16777344</Property>
 			<Property Name="NI.ClassItem.IsStaticMethod" Type="Bool">false</Property>
 			<Property Name="NI.ClassItem.MethodScope" Type="UInt">1</Property>
+			<Property Name="NI.ClassItem.MustOverride" Type="Bool">false</Property>
 			<Property Name="NI.ClassItem.Priority" Type="Int">1</Property>
-			<Property Name="NI.ClassItem.State" Type="Int">1342972416</Property>
+			<Property Name="NI.ClassItem.State" Type="Int">1082139136</Property>
 		</Item>
 		<Item Name="Open Handle.vi" Type="VI" URL="../Open Handle.vi">
-			<Property Name="NI.ClassItem.ConnectorPane" Type="Bin">)!#!!!!!!!)!"1!&amp;!!!-!%!!!@````]!!!!"!!%!!!(8!!!!$1!-1#%'=X2B&gt;(6T!!!,1!-!"'.P:'5!!""!-0````]'=W^V=G.F!!!71&amp;!!!Q!!!!%!!AFF=H*P=C"P&gt;81!"!!!!':!=!!?!!"$'EB56&amp;!A1WRJ:7ZU)%&amp;C=X2S97.U,GRW&lt;'FC*E&amp;C=X2S97.U)%B56&amp;!A1WRJ:7ZU)%FO&gt;'6S:G&amp;D:3ZM&gt;G.M98.T!"B)6&amp;21)%.M;76O&gt;#""9H.U=G&amp;D&gt;#"P&gt;81!!"B!)2.W:8*J:HEA=W6S&gt;G6S+(2S&gt;75J!"2!-P````],9W^P;WFF)':J&lt;'5!)%"1!!-!!!!"!!)4:8*S&lt;X)A;7YA+'ZP)'6S=G^S+1!31$$`````#("B=X.X&lt;X*E!!!31$$`````#(6T:8*O97VF!!"E1(!!(A!!1RJ)6&amp;21)%.M;76O&gt;#""9H.U=G&amp;D&gt;#ZM&gt;GRJ9C:"9H.U=G&amp;D&gt;#")6&amp;21)%.M;76O&gt;#"*&lt;H2F=G:B9W5O&lt;(:D&lt;'&amp;T=Q!83&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1A;7Y!6!$Q!!Q!!Q!%!!1!"1!%!!1!"A!(!!A!#1!+!!M$!!"Y!!!.#!!!!!!!!!!!!!#.#Q!!!!!!!!!!!!!)!!!!#!!!!!I!!!))!!!##!!!!*!!!!!!!1!-!!!!!!</Property>
+			<Property Name="NI.ClassItem.ConnectorPane" Type="Bin">)!#!!!!!!!)!"1!&amp;!!!-!%!!!@````]!!!!"!!%!!!($!!!!$1!-1#%'=X2B&gt;(6T!!!,1!-!"'.P:'5!!""!-0````]'=W^V=G.F!!!71&amp;!!!Q!!!!%!!AFF=H*P=C"P&gt;81!"!!!!&amp;R!=!!?!!!Z'EB56&amp;!A1WRJ:7ZU)%&amp;C=X2S97.U,GRW&lt;'FC(%&amp;C=X2S97.U)%B56&amp;!A1WRJ:7ZU,GRW9WRB=X-!'%B56&amp;!A1WRJ:7ZU)%&amp;C=X2S97.U)'^V&gt;!!!'%!B%X:F=GFG?3"T:8*W:8)I&gt;(*V:3E!&amp;%!S`````QND&lt;W^L;75A:GFM:1!A1&amp;!!!Q!!!!%!!B.F=H*P=C"J&lt;C!I&lt;G]A:8*S&lt;X)J!"*!-0````])='&amp;T=X&gt;P=G1!!"*!-0````])&gt;8.F=GZB&lt;75!!&amp;J!=!!?!!!Z'EB56&amp;!A1WRJ:7ZU)%&amp;C=X2S97.U,GRW&lt;'FC(%&amp;C=X2S97.U)%B56&amp;!A1WRJ:7ZU,GRW9WRB=X-!&amp;UB56&amp;!A1WRJ:7ZU)%&amp;C=X2S97.U)'FO!&amp;1!]!!-!!-!"!!%!!5!"!!%!!9!"Q!)!!E!#A!,!Q!!?!!!$1A!!!!!!!!!!!!!C1!!!!!!!!!!!!!!#!!!!!A!!!!+!!!"#A!!!1I!!!#1!!!!!!%!$!!!!!!</Property>
 			<Property Name="NI.ClassItem.ExecutionSystem" Type="Int">-1</Property>
 			<Property Name="NI.ClassItem.Flags" Type="Int">16777344</Property>
 			<Property Name="NI.ClassItem.IsStaticMethod" Type="Bool">false</Property>
 			<Property Name="NI.ClassItem.MethodScope" Type="UInt">1</Property>
 			<Property Name="NI.ClassItem.Priority" Type="Int">1</Property>
-			<Property Name="NI.ClassItem.State" Type="Int">1082401296</Property>
+			<Property Name="NI.ClassItem.State" Type="Int">1107821072</Property>
 		</Item>
 		<Item Name="Remove Header.vi" Type="VI" URL="../Remove Header.vi">
-			<Property Name="NI.ClassItem.ConnectorPane" Type="Bin">)!#!!!!!!!)!"1!&amp;!!!-!%!!!@````]!!!!"!!%!!!'8!!!!#A!-1#%'=X2B&gt;(6T!!!,1!-!"'.P:'5!!""!-0````]'=W^V=G.F!!!71&amp;!!!Q!!!!%!!AFF=H*P=C"P&gt;81!"!!!!':!=!!?!!"$'EB56&amp;!A1WRJ:7ZU)%&amp;C=X2S97.U,GRW&lt;'FC*E&amp;C=X2S97.U)%B56&amp;!A1WRJ:7ZU)%FO&gt;'6S:G&amp;D:3ZM&gt;G.M98.T!"B)6&amp;21)%.M;76O&gt;#""9H.U=G&amp;D&gt;#"P&gt;81!!#"!5!!$!!!!!1!#%W6S=G^S)'FO)#BO&lt;S"F=H*P=CE!%%!Q`````Q:I:7&amp;E:8)!!'2!=!!?!!"$'EB56&amp;!A1WRJ:7ZU)%&amp;C=X2S97.U,GRW&lt;'FC*E&amp;C=X2S97.U)%B56&amp;!A1WRJ:7ZU)%FO&gt;'6S:G&amp;D:3ZM&gt;G.M98.T!"&gt;)6&amp;21)%.M;76O&gt;#""9H.U=G&amp;D&gt;#"J&lt;A"5!0!!$!!$!!1!"!!&amp;!!1!"!!%!!1!"A!%!!=!#!)!!(A!!!U)!!!!!!!!!!!!!)U,!!!!!!!!!!!!!!!!!!!!!!!!#!!!!!!!!!))!!!!E!!!!!!"!!E!!!!!</Property>
+			<Property Name="NI.ClassItem.ConnectorPane" Type="Bin">)!#!!!!!!!)!"1!&amp;!!!-!%!!!@````]!!!!"!!%!!!'$!!!!#A!-1#%'=X2B&gt;(6T!!!,1!-!"'.P:'5!!""!-0````]'=W^V=G.F!!!71&amp;!!!Q!!!!%!!AFF=H*P=C"P&gt;81!"!!!!&amp;R!=!!?!!!Z'EB56&amp;!A1WRJ:7ZU)%&amp;C=X2S97.U,GRW&lt;'FC(%&amp;C=X2S97.U)%B56&amp;!A1WRJ:7ZU,GRW9WRB=X-!'%B56&amp;!A1WRJ:7ZU)%&amp;C=X2S97.U)'^V&gt;!!!)%"1!!-!!!!"!!)4:8*S&lt;X)A;7YA+'ZP)'6S=G^S+1!11$$`````"GBF972F=A!!7E"Q!"Y!!$E;3&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1O&lt;(:M;7)=17*T&gt;(*B9X1A3&amp;255#"$&lt;'FF&lt;H1O&lt;(:D&lt;'&amp;T=Q!83&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1A;7Y!6!$Q!!Q!!Q!%!!1!"1!%!!1!"!!%!!9!"!!(!!A#!!"Y!!!.#!!!!!!!!!!!!!#.#Q!!!!!!!!!!!!!!!!!!!!!!!!A!!!!!!!!##!!!!*!!!!!!!1!*!!!!!!</Property>
 			<Property Name="NI.ClassItem.ExecutionSystem" Type="Int">-1</Property>
 			<Property Name="NI.ClassItem.Flags" Type="Int">16777344</Property>
 			<Property Name="NI.ClassItem.IsStaticMethod" Type="Bool">false</Property>
 			<Property Name="NI.ClassItem.MethodScope" Type="UInt">1</Property>
+			<Property Name="NI.ClassItem.MustOverride" Type="Bool">false</Property>
 			<Property Name="NI.ClassItem.Priority" Type="Int">1</Property>
-			<Property Name="NI.ClassItem.State" Type="Int">1342972416</Property>
+			<Property Name="NI.ClassItem.State" Type="Int">1082139136</Property>
 		</Item>
 	</Item>
 	<Item Name="SubVIs" Type="Folder">
@@ -180,12 +195,12 @@
 		</Item>
 	</Item>
 	<Item Name="Get Default HTTP Client Implementation.vi" Type="VI" URL="../support/Get Default HTTP Client Implementation.vi">
-		<Property Name="NI.ClassItem.ConnectorPane" Type="Bin">)!#!!!!!!!)!"1!&amp;!!!-!%!!!@````]!!!!"!!%!!!$'!!!!!Q!%!!!!:E"Q!"Y!!%-;3&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1O&lt;(:M;7)G17*T&gt;(*B9X1A3&amp;255#"$&lt;'FF&lt;H1A37ZU:8*G97.F,GRW9WRB=X-!'%B56&amp;!A1WRJ:7ZU)%&amp;C=X2S97.U)'^V&gt;!!!6!$Q!!Q!!!!!!!!!!1!!!!!!!!!!!!!!!!!!!!!#!!"Y!!!!!!!!!!!!!!!!!!!*!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!1!#!!!!!!</Property>
+		<Property Name="NI.ClassItem.ConnectorPane" Type="Bin">)!#!!!!!!!)!"1!&amp;!!!-!%!!!@````]!!!!"!!%!!!#]!!!!!Q!%!!!!8%"Q!"Y!!$E;3&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1O&lt;(:M;7)=17*T&gt;(*B9X1A3&amp;255#"$&lt;'FF&lt;H1O&lt;(:D&lt;'&amp;T=Q!93&amp;255#"$&lt;'FF&lt;H1A17*T&gt;(*B9X1A&lt;X6U!!"5!0!!$!!!!!!!!!!"!!!!!!!!!!!!!!!!!!!!!!)!!(A!!!!!!!!!!!!!!!!!!!E!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"!!)!!!!!</Property>
 		<Property Name="NI.ClassItem.ExecutionSystem" Type="Int">-1</Property>
 		<Property Name="NI.ClassItem.Flags" Type="Int">16777344</Property>
 		<Property Name="NI.ClassItem.IsStaticMethod" Type="Bool">true</Property>
 		<Property Name="NI.ClassItem.MethodScope" Type="UInt">1</Property>
 		<Property Name="NI.ClassItem.Priority" Type="Int">1</Property>
-		<Property Name="NI.ClassItem.State" Type="Int">1342972416</Property>
+		<Property Name="NI.ClassItem.State" Type="Int">1082401280</Property>
 	</Item>
 </LVClass>


### PR DESCRIPTION
- now only `Open Session.vi` and `Close Session.vi` require overrides, so that implementations can choose which ones to override. Default implementations will return errors so that callers know that a plug-in is missing that method.